### PR TITLE
In 105347574 gem invalid date conversion

### DIFF
--- a/lib/is_valid_multiparameter_date_time_validator.rb
+++ b/lib/is_valid_multiparameter_date_time_validator.rb
@@ -20,6 +20,7 @@ class IsValidMultiparameterDateTimeValidator < ActiveModel::EachValidator
     else
       attribute_value = record.public_send(:"#{attribute}_time_part")
       begin
+        Date.parse(date_value)
         Time.zone.parse("#{date_value} #{time_value}")
         Time.zone.parse(attribute_value)
       rescue ArgumentError

--- a/lib/multiparameter_date_time.rb
+++ b/lib/multiparameter_date_time.rb
@@ -117,9 +117,13 @@ module MultiparameterDateTime
           formatted_date_string = MultiparameterDateTime.date_string_formatter.format(date_string)
         end
 
-        write_attribute_for_multiparameter_date_time(
-          name, Time.zone.parse("#{formatted_date_string} #{time_string}")
-        )
+        if Date.parse(formatted_date_string)
+          write_attribute_for_multiparameter_date_time(
+            name, Time.zone.parse("#{formatted_date_string} #{time_string}")
+          )
+        else
+          write_attribute_for_multiparameter_date_time(name, :incomplete)
+        end
       rescue ArgumentError
         write_attribute_for_multiparameter_date_time(name, :incomplete)
       end

--- a/spec/is_valid_multiparameter_date_time_validator_spec.rb
+++ b/spec/is_valid_multiparameter_date_time_validator_spec.rb
@@ -308,6 +308,24 @@ describe IsValidMultiparameterDateTimeValidator do
 
         it_should_behave_like 'a badly formatted date or time'
       end
+
+      context 'having a valid month but invalid day for that month' do
+        context 'set in parts' do
+          let(:record) do
+            ModelWithDatetime.new(foo_date_part: '2/31/2015', foo_time_part: '04:50pm')
+          end
+
+          it_should_behave_like 'a badly formatted date or time'
+        end
+
+        context 'set directly' do
+          let(:record) do
+            ModelWithDatetime.new(foo: '2/31/2015 04:50pm')
+          end
+
+          it_should_behave_like 'a badly formatted date or time'
+        end
+      end
     end
 
     context 'with an impossible time' do

--- a/spec/is_valid_multiparameter_date_time_validator_spec.rb
+++ b/spec/is_valid_multiparameter_date_time_validator_spec.rb
@@ -21,16 +21,16 @@ describe IsValidMultiparameterDateTimeValidator do
   end
 
   shared_examples_for "a valid time" do
-    it "should not have an error" do
+    it "does not have an error" do
       record.valid?
-      record.errors[:foo].should be_empty
+      expect(record.errors[:foo]).to be_empty
     end
   end
 
   shared_examples_for "a badly formatted date or time" do
-    it "should show the bad format error" do
+    it "shows the bad format error" do
       record.valid?
-      record.errors[:foo].should == [bad_format_error]
+      expect(record.errors[:foo]).to eq [bad_format_error]
     end
   end
 
@@ -220,7 +220,7 @@ describe IsValidMultiparameterDateTimeValidator do
 
           it "should show the missing date error" do
             record.valid?
-            record.errors[:foo].should == [missing_date_error]
+            expect(record.errors[:foo]).to eq [missing_date_error]
           end
         end
 
@@ -235,7 +235,7 @@ describe IsValidMultiparameterDateTimeValidator do
             let(:time_string) { time_value }
             it 'should not have an error' do
               record.valid?
-              record.errors[:foo].should be_empty
+              expect(record.errors[:foo]).to be_empty
             end
           end
         end
@@ -262,7 +262,7 @@ describe IsValidMultiparameterDateTimeValidator do
         context 'and I18n error messages' do
           it "should show the missing date error" do
             record.valid?
-            record.errors[:foo].should == ['custom error']
+            expect(record.errors[:foo]).to eq ['custom error']
           end
         end
       end
@@ -272,7 +272,7 @@ describe IsValidMultiparameterDateTimeValidator do
       let(:record) { ModelWithDatetime.new(foo: Time.current) }
       it "should not have an error" do
         record.valid?
-        record.errors[:foo].should be_empty
+        expect(record.errors[:foo]).to be_empty
       end
     end
 
@@ -280,7 +280,7 @@ describe IsValidMultiparameterDateTimeValidator do
       let(:record) { ModelWithDatetime.new(foo: nil) }
       it "should not have an error" do
         record.valid?
-        record.errors[:foo].should be_empty
+        expect(record.errors[:foo]).to be_empty
       end
     end
 
@@ -288,7 +288,7 @@ describe IsValidMultiparameterDateTimeValidator do
       let(:record) { ModelWithDatetime.new }
       it "should not have an error" do
         record.valid?
-        record.errors[:foo].should be_empty
+        expect(record.errors[:foo]).to be_empty
       end
     end
 
@@ -337,9 +337,9 @@ describe IsValidMultiparameterDateTimeValidator do
           MultiparameterDateTime.date_format = '%-m-%-e-%0y'
         end
 
-        it "should show the bad format error" do
+        it "shows the bad format error" do
           record.valid?
-          record.errors[:foo].should == [
+          expect(record.errors[:foo]).to eq [
             'Please enter a valid date and time using the following formats: 1-29-00, 5:15 pm'
           ]
         end
@@ -356,9 +356,9 @@ describe IsValidMultiparameterDateTimeValidator do
           MultiparameterDateTime.time_format = '%H%M hours'
         end
 
-        it "should show the bad format error" do
+        it "shows the bad format error" do
           record.valid?
-          record.errors[:foo].should == [
+          expect(record.errors[:foo]).to eq [
             'Please enter a valid date and time using the following formats: 1/29/2000, 1715 hours'
           ]
         end
@@ -379,8 +379,8 @@ describe IsValidMultiparameterDateTimeValidator do
           ModelWithDatetime.new(foo_date_part: date_string, foo_time_part: time_string)
         end
 
-        it "should be accepted" do
-          record.should be_valid
+        it "is accepted" do
+          expect(record).to be_valid
         end
       end
     end

--- a/spec/is_valid_multiparameter_date_time_validator_spec.rb
+++ b/spec/is_valid_multiparameter_date_time_validator_spec.rb
@@ -5,7 +5,7 @@ require 'is_valid_multiparameter_date_time_validator'
 
 describe IsValidMultiparameterDateTimeValidator do
   before do
-    Time.zone = "US/Eastern"
+    Time.zone = 'US/Eastern'
   end
 
   with_model :ModelWithDatetime do
@@ -20,21 +20,21 @@ describe IsValidMultiparameterDateTimeValidator do
     end
   end
 
-  shared_examples_for "a valid time" do
-    it "does not have an error" do
+  shared_examples_for 'a valid time' do
+    it 'does not have an error' do
       record.valid?
       expect(record.errors[:foo]).to be_empty
     end
   end
 
-  shared_examples_for "a badly formatted date or time" do
-    it "shows the bad format error" do
+  shared_examples_for 'a badly formatted date or time' do
+    it 'shows the bad format error' do
       record.valid?
       expect(record.errors[:foo]).to eq [bad_format_error]
     end
   end
 
-  describe "#validate_each" do
+  describe '#validate_each' do
     subject { record }
     let(:record) do
       ModelWithDatetime.new(
@@ -49,75 +49,75 @@ describe IsValidMultiparameterDateTimeValidator do
     let(:missing_time_error) { 'Please enter a time.' }
     let(:missing_date_error) { 'Please enter a date.' }
 
-    context "with valid date" do
+    context 'with valid date' do
       let(:date_string) { '01/01/2001' }
 
-      context "with valid time in" do
-        context "military format" do
-          context "lots of zeros" do
+      context 'with valid time in' do
+        context 'military format' do
+          context 'lots of zeros' do
             let(:time_string) { '00:00' }
-            it_should_behave_like "a valid time"
+            it_should_behave_like 'a valid time'
           end
 
-          context "last valid value" do
+          context 'last valid value' do
             let(:time_string) { '23:59' }
-            it_should_behave_like "a valid time"
+            it_should_behave_like 'a valid time'
           end
 
-          context "1 pm" do
+          context '1 pm' do
             let(:time_string) { '13:00' }
-            it_should_behave_like "a valid time"
+            it_should_behave_like 'a valid time'
           end
         end
 
-        context "standard format" do
+        context 'standard format' do
           let(:time_string) { '12:31pm' }
-          it_should_behave_like "a valid time"
+          it_should_behave_like 'a valid time'
 
-          context "with a capital AM or PM" do
+          context 'with a capital AM or PM' do
             let(:time_string) { '12:31 PM' }
-            it_should_behave_like "a valid time"
+            it_should_behave_like 'a valid time'
           end
 
-          context "without a space between the time and AM or PM" do
+          context 'without a space between the time and AM or PM' do
             let(:time_string) { '12:31AM' }
-            it_should_behave_like "a valid time"
+            it_should_behave_like 'a valid time'
           end
 
-          context "with no space and a mixed case aM or pM" do
+          context 'with no space and a mixed case aM or pM' do
             let(:time_string) { '12:31aM' }
-            it_should_behave_like "a valid time"
+            it_should_behave_like 'a valid time'
           end
 
-          context "with a space and a mixed case aM or pM" do
+          context 'with a space and a mixed case aM or pM' do
             let(:time_string) { '12:31 aM' }
-            it_should_behave_like "a valid time"
+            it_should_behave_like 'a valid time'
           end
 
-          context "with a space and a lower case am or pm" do
+          context 'with a space and a lower case am or pm' do
             let(:time_string) { '12:31 am' }
-            it_should_behave_like "a valid time"
+            it_should_behave_like 'a valid time'
           end
         end
       end
 
-      context "with invalid time in" do
-        context "military format" do
-          context "above 23:59" do
+      context 'with invalid time in' do
+        context 'military format' do
+          context 'above 23:59' do
             let(:time_string) { '25:00' }
-            it_should_behave_like "a badly formatted date or time"
+            it_should_behave_like 'a badly formatted date or time'
           end
 
-          context "with am or pm" do
+          context 'with am or pm' do
             let(:time_string) { '23:00 am' }
-            it_should_behave_like "a badly formatted date or time"
+            it_should_behave_like 'a badly formatted date or time'
           end
         end
 
-        context "standard format" do
+        context 'standard format' do
           let(:time_string) { '90:00pm' }
 
-          it_should_behave_like "a badly formatted date or time"
+          it_should_behave_like 'a badly formatted date or time'
         end
       end
 
@@ -158,56 +158,56 @@ describe IsValidMultiparameterDateTimeValidator do
       end
     end
 
-    context "with invalid date" do
+    context 'with invalid date' do
       let(:date_string) { 'asdf' }
 
-      context "with valid time" do
+      context 'with valid time' do
         let(:time_string) { '12:31pm' }
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
 
-      context "with invalid time" do
+      context 'with invalid time' do
         let(:time_string) { 'asdf' }
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
 
       [' ', nil].each do |time_value|
         context "with time = #{time_value.inspect}" do
           let(:time_string) { time_value }
-          it_should_behave_like "a badly formatted date or time"
+          it_should_behave_like 'a badly formatted date or time'
         end
       end
     end
 
-    context "with a date that has invalid format" do
-      context "with year has 5 digits" do
+    context 'with a date that has invalid format' do
+      context 'with year has 5 digits' do
         let(:date_string) { '1/1/12012' }
         let(:time_string) { '12:31pm' }
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
 
-      context "with year has 1 digit" do
+      context 'with year has 1 digit' do
         let(:date_string) { '1/1/2' }
         let(:time_string) { '12:31pm' }
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
 
-      context "with month has 3 digits" do
+      context 'with month has 3 digits' do
         let(:date_string) { '100/1/2012' }
         let(:time_string) { '12:31pm' }
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
 
-      context "with day has 3 digits" do
+      context 'with day has 3 digits' do
         let(:date_string) { '10/100/2012' }
         let(:time_string) { '12:31pm' }
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
     end
 
@@ -215,19 +215,19 @@ describe IsValidMultiparameterDateTimeValidator do
       context "with date = #{date_value.inspect}" do
         let(:date_string) { date_value }
 
-        context "with valid time" do
+        context 'with valid time' do
           let(:time_string) { '12:31pm' }
 
-          it "should show the missing date error" do
+          it 'should show the missing date error' do
             record.valid?
             expect(record.errors[:foo]).to eq [missing_date_error]
           end
         end
 
-        context "with invalid time" do
+        context 'with invalid time' do
           let(:time_string) { 'asdf' }
 
-          it_should_behave_like "a badly formatted date or time"
+          it_should_behave_like 'a badly formatted date or time'
         end
 
         [' ', nil].each do |time_value|
@@ -243,7 +243,7 @@ describe IsValidMultiparameterDateTimeValidator do
     end
 
     [' ', nil].each do |date_value|
-      context "with valid time" do
+      context 'with valid time' do
         let(:date_string) { date_value }
         let(:time_string) { '12:31pm' }
 
@@ -260,7 +260,7 @@ describe IsValidMultiparameterDateTimeValidator do
         end
 
         context 'and I18n error messages' do
-          it "should show the missing date error" do
+          it 'should show the missing date error' do
             record.valid?
             expect(record.errors[:foo]).to eq ['custom error']
           end
@@ -268,76 +268,76 @@ describe IsValidMultiparameterDateTimeValidator do
       end
     end
 
-    context "when the datetime is set directly" do
+    context 'when the datetime is set directly' do
       let(:record) { ModelWithDatetime.new(foo: Time.current) }
-      it "should not have an error" do
+      it 'should not have an error' do
         record.valid?
         expect(record.errors[:foo]).to be_empty
       end
     end
 
-    context "when the datetime is set directly to nil" do
+    context 'when the datetime is set directly to nil' do
       let(:record) { ModelWithDatetime.new(foo: nil) }
-      it "should not have an error" do
+      it 'should not have an error' do
         record.valid?
         expect(record.errors[:foo]).to be_empty
       end
     end
 
-    context "when nothing is set at all" do
+    context 'when nothing is set at all' do
       let(:record) { ModelWithDatetime.new }
-      it "should not have an error" do
+      it 'should not have an error' do
         record.valid?
         expect(record.errors[:foo]).to be_empty
       end
     end
 
-    context "with an impossible date" do
-      context "set in parts" do
+    context 'with an impossible date' do
+      context 'set in parts' do
         let(:record) do
           ModelWithDatetime.new(foo_date_part: '19/19/1919', foo_time_part: '04:50pm')
         end
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
 
-      context "set directly" do
+      context 'set directly' do
         let(:record) do
           ModelWithDatetime.new(foo: '19/19/1919 04:50pm')
         end
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
     end
 
-    context "with an impossible time" do
-      context "set in parts" do
+    context 'with an impossible time' do
+      context 'set in parts' do
         let(:record) do
           ModelWithDatetime.new(foo_date_part: '01/01/2001', foo_time_part: '09:99pm')
         end
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
 
-      context "set directly" do
+      context 'set directly' do
         let(:record) do
           ModelWithDatetime.new(foo: '01/01/2001 09:99pm')
         end
 
-        it_should_behave_like "a badly formatted date or time"
+        it_should_behave_like 'a badly formatted date or time'
       end
     end
 
-    context "when the display format has been configured" do
+    context 'when the display format has been configured' do
       let(:date_string) { 'asdf' }
       let(:time_string) { 'foo' }
 
-      context "when the date format is set" do
+      context 'when the date format is set' do
         before do
           MultiparameterDateTime.date_format = '%-m-%-e-%0y'
         end
 
-        it "shows the bad format error" do
+        it 'shows the bad format error' do
           record.valid?
           expect(record.errors[:foo]).to eq [
             'Please enter a valid date and time using the following formats: 1-29-00, 5:15 pm'
@@ -349,14 +349,14 @@ describe IsValidMultiparameterDateTimeValidator do
         end
       end
 
-      context "when the time format is set" do
+      context 'when the time format is set' do
         let(:time_string) { 'asdf' }
 
         before do
           MultiparameterDateTime.time_format = '%H%M hours'
         end
 
-        it "shows the bad format error" do
+        it 'shows the bad format error' do
           record.valid?
           expect(record.errors[:foo]).to eq [
             'Please enter a valid date and time using the following formats: 1/29/2000, 1715 hours'
@@ -370,7 +370,7 @@ describe IsValidMultiparameterDateTimeValidator do
     end
   end
 
-  describe "accepts dates in a variety of formats" do
+  describe 'accepts dates in a variety of formats' do
     ['2010-1-1', '02-01-1971', '4/4/92', '01/02/2001', '01/02/2001', '01.02.2011'].each do |format|
       context format do
         let(:date_string) { format }
@@ -379,14 +379,14 @@ describe IsValidMultiparameterDateTimeValidator do
           ModelWithDatetime.new(foo_date_part: date_string, foo_time_part: time_string)
         end
 
-        it "is accepted" do
+        it 'is accepted' do
           expect(record).to be_valid
         end
       end
     end
   end
 
-  describe ".invalid_format_error_message" do
+  describe '.invalid_format_error_message' do
     it do
       expected_error = 'Please enter a valid date and time using the following formats: 1/29/2000, 5:15 pm'
       expect(described_class.invalid_format_error_message).to eq expected_error

--- a/spec/multiparameter_date_time_spec.rb
+++ b/spec/multiparameter_date_time_spec.rb
@@ -40,7 +40,7 @@ describe MultiparameterDateTime do
 
         subject { record }
 
-        describe "when a value is present" do
+        describe 'when a value is present' do
           let(:record) { model.new(foo: Time.zone.parse('1/2/2003 04:05pm')) }
           it 'assigns date_part' do
             expect(subject.foo_date_part).to eq '1/2/2003'
@@ -51,304 +51,304 @@ describe MultiparameterDateTime do
           end
         end
 
-        describe "setting a valid date and time" do
+        describe 'setting a valid date and time' do
           let(:foo_date_part) { '01/02/2000' }
           let(:foo_time_part) { '9:30 pm EST' }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to a DateTime object" do
+          it 'sets the attribute to a DateTime object' do
             expect(subject.foo).to eq Time.zone.parse('1/2/2000 9:30 pm')
           end
 
-          it "has the original date input" do
+          it 'has the original date input' do
             expect(subject.foo_date_part).to eq '01/02/2000'
           end
 
-          it "has the original time input" do
+          it 'has the original time input' do
             expect(subject.foo_time_part).to eq '9:30 pm EST'
           end
         end
 
-        describe "setting an invalid date" do
+        describe 'setting an invalid date' do
           let(:foo_date_part) { 'bad input' }
           let(:foo_time_part) { '9:30 pm' }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to :incomplete" do
+          it 'sets the attribute to :incomplete' do
             expect(subject.foo).to eq :incomplete
           end
 
-          it "has the original date" do
+          it 'has the original date' do
             expect(subject.foo_date_part).to eq 'bad input'
           end
 
-          it "has the original time input" do
+          it 'has the original time input' do
             expect(subject.foo_time_part).to eq '9:30 pm'
           end
         end
 
-        describe "setting a impossible date" do
+        describe 'setting a impossible date' do
           let(:foo_date_part) { '99/99/9999' }
           let(:foo_time_part) { '12:30 pm' }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to :incomplete" do
+          it 'sets the attribute to :incomplete' do
             expect(subject.foo).to eq :incomplete
           end
 
-          it "has the original date" do
+          it 'has the original date' do
             expect(subject.foo_date_part).to eq '99/99/9999'
           end
 
-          it "has the original time" do
+          it 'has the original time' do
             expect(subject.foo_time_part).to eq '12:30 pm'
           end
         end
 
-        describe "setting an invalid time" do
+        describe 'setting an invalid time' do
           let(:foo_date_part) { '01/02/2000' }
           let(:foo_time_part) { 'bad input' }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to :incomplete" do
+          it 'sets the attribute to :incomplete' do
             expect(subject.foo).to eq :incomplete
           end
 
-          it "has the original date input" do
+          it 'has the original date input' do
             expect(subject.foo_date_part).to eq '01/02/2000'
           end
 
-          it "has the original time input" do
-            expect(subject.foo_time_part).to eq "bad input"
+          it 'has the original time input' do
+            expect(subject.foo_time_part).to eq 'bad input'
           end
         end
 
-        describe "setting a impossible time" do
+        describe 'setting a impossible time' do
           let(:foo_date_part) { '01/02/2000' }
           let(:foo_time_part) { '99:99pm' }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to :incomplete" do
+          it 'sets the attribute to :incomplete' do
             expect(subject.foo).to eq :incomplete
           end
 
-          it "has the original date input" do
+          it 'has the original date input' do
             expect(subject.foo_date_part).to eq '01/02/2000'
           end
 
-          it "has the original time input" do
+          it 'has the original time input' do
             expect(subject.foo_time_part).to eq '99:99pm'
           end
         end
 
-        describe "setting a date but not a time" do
+        describe 'setting a date but not a time' do
           let(:record) { model.new(foo_date_part: '01/01/2000') }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to :incomplete" do
+          it 'sets the attribute to :incomplete' do
             expect(subject.foo).to eq :incomplete
           end
 
-          it "has the original date" do
+          it 'has the original date' do
             expect(subject.foo_date_part).to eq '01/01/2000'
           end
 
-          it "has the nil for the time input" do
+          it 'has the nil for the time input' do
             expect(subject.foo_time_part).to eq nil
           end
         end
 
-        describe "setting a time but not a date" do
+        describe 'setting a time but not a date' do
           let(:record) { model.new(foo_time_part: '12:30 pm') }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to :incomplete" do
+          it 'sets the attribute to :incomplete' do
             expect(subject.foo).to eq :incomplete
           end
 
-          it "has the nil for the date input" do
+          it 'has the nil for the date input' do
             expect(subject.foo_date_part).to eq nil
           end
 
-          it "has the original time" do
+          it 'has the original time' do
             expect(subject.foo_time_part).to eq '12:30 pm'
           end
         end
 
-        describe "setting incorrect time and date" do
+        describe 'setting incorrect time and date' do
           let(:record) { model.new(foo_time_part: 'qwer',
                                    foo_date_part: 'asdf') }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to :incomplete" do
+          it 'sets the attribute to :incomplete' do
             expect(subject.foo).to eq :incomplete
           end
 
-          it "has the original date" do
+          it 'has the original date' do
             expect(subject.foo_date_part).to eq 'asdf'
           end
 
-          it "has the original time input" do
+          it 'has the original time input' do
             expect(subject.foo_time_part).to eq 'qwer'
           end
         end
 
-        describe "setting neither time nor a date" do
+        describe 'setting neither time nor a date' do
           let(:record) { model.new(foo_time_part: '',
                                    foo_date_part: '') }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "has nil for the attribute" do
+          it 'has nil for the attribute' do
             expect(subject.foo).to eq nil
           end
 
-          it "has the original date" do
+          it 'has the original date' do
             expect(subject.foo_date_part).to eq ''
           end
 
-          it "has the original time input" do
+          it 'has the original time input' do
             expect(subject.foo_time_part).to eq ''
           end
         end
 
-        describe "setting a DateTime directly" do
+        describe 'setting a DateTime directly' do
           let(:record) { model.new(foo: Time.zone.parse("#{foo_date_part} #{foo_time_part}")) }
           let(:foo_date_part) { '01/02/2000' }
           let(:foo_time_part) { '12:30 pm' }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to a DateTime object" do
+          it 'sets the attribute to a DateTime object' do
             expect(subject.foo).to eq Time.zone.parse('01/02/2000 12:30 pm')
           end
 
-          it "has the original date" do
+          it 'has the original date' do
             expect(subject.foo_date_part).to eq '1/2/2000'
           end
 
-          it "has the original time input" do
+          it 'has the original time input' do
             expect(subject.foo_time_part).to eq '12:30 pm'
           end
         end
 
-        describe "setting a String directly" do
-          context "When the string contains a date and time" do
+        describe 'setting a String directly' do
+          context 'When the string contains a date and time' do
             let(:record) { model.new(foo: "#{foo_date_part} #{foo_time_part}") }
             let(:foo_date_part) { '01/01/2000' }
             let(:foo_time_part) { '12:30 pm' }
 
-            it "doesn't raise an exception" do
+            it 'does not raise an exception' do
               expect { subject }.not_to raise_exception
             end
 
-            it "sets the attribute to a DateTime object" do
+            it 'sets the attribute to a DateTime object' do
               expect(subject.foo).to eq Time.zone.parse('01/01/2000 12:30pm')
             end
 
-            it "has the original date" do
+            it 'has the original date' do
               expect(subject.foo_date_part).to eq '01/01/2000'
             end
 
-            it "has the original time" do
+            it 'has the original time' do
               expect(subject.foo_time_part).to eq '12:30 pm'
             end
           end
 
-          context "When the string contains an iso8601 datetime" do
+          context 'When the string contains an iso8601 datetime' do
             let(:record) { model.new(foo: '2011-12-03T01:00:00Z') }
 
-            it "doesn't raise an exception" do
+            it 'does not raise an exception' do
               expect { subject }.not_to raise_exception
             end
 
-            it "sets the attribute to a DateTime object with the correct EST time" do
+            it 'sets the attribute to a DateTime object with the correct EST time' do
               expect(subject.foo).to eq Time.zone.parse('12/2/2011 8:00 pm')
             end
 
-            it "has a date" do
+            it 'has a date' do
               expect(subject.foo_date_part).to eq '12/2/2011'
             end
 
-            it "has a time" do
+            it 'has a time' do
               expect(subject.foo_time_part).to eq '8:00 pm'
             end
           end
 
-          context "When the string contains only a date" do
+          context 'When the string contains only a date' do
             let(:record) { model.new(foo: "#{foo_date_part}") }
             let(:foo_date_part) { '01/01/2000' }
 
-            it "doesn't raise an exception" do
+            it 'does not raise an exception' do
               expect { subject }.not_to raise_exception
             end
 
-            it "sets the attribute to a DateTime object" do
+            it 'sets the attribute to a DateTime object' do
               expect(subject.foo).to eq Time.zone.parse('01/01/2000 12:00am')
             end
 
-            it "has the original date" do
+            it 'has the original date' do
               expect(subject.foo_date_part).to eq '1/1/2000'
             end
 
-            it "has midnight for the time input" do
+            it 'has midnight for the time input' do
               expect(subject.foo_time_part).to eq '12:00 am'
             end
           end
         end
 
-        describe "setting a Date directly" do
+        describe 'setting a Date directly' do
           let(:record) { model.new(foo: Date.parse(foo_date_part)) }
 
           let(:foo_date_part) { '01/01/2000' }
 
-          it "doesn't raise an exception" do
+          it 'does not raise an exception' do
             expect { subject }.not_to raise_exception
           end
 
-          it "sets the attribute to a DateTime object in the current time zone" do
+          it 'sets the attribute to a DateTime object in the current time zone' do
             expect(subject.foo).to eq Time.zone.parse('01/01/2000 12:00 am')
           end
 
-          it "has the original date" do
+          it 'has the original date' do
             expect(subject.foo_date_part).to eq '1/1/2000'
           end
 
-          it "has midnight for the time input" do
+          it 'has midnight for the time input' do
             expect(subject.foo_time_part).to eq '12:00 am'
           end
         end
 
-        describe "setting to nil" do
-          it "is nil" do
+        describe 'setting to nil' do
+          it 'is nil' do
             record = ModelWithDateTime.new
             record.foo = Time.current
             record.foo = nil
@@ -356,19 +356,19 @@ describe MultiparameterDateTime do
           end
         end
 
-        describe "configuring the datetime format" do
+        describe 'configuring the datetime format' do
           let(:record) { model.new(foo: Time.zone.parse('01/09/2000 1:30 pm')) }
 
-          context "when the date format is set" do
+          context 'when the date format is set' do
             before do
               MultiparameterDateTime.date_format = '%-m-%-e-%0y'
             end
 
-            it "formats the date properly" do
+            it 'formats the date properly' do
               expect(subject.foo_date_part).to eq '1-9-00'
             end
 
-            it "uses the default format for the time" do
+            it 'uses the default format for the time' do
               expect(subject.foo_time_part).to eq '1:30 pm'
             end
 
@@ -377,16 +377,16 @@ describe MultiparameterDateTime do
             end
           end
 
-          context "when the time format is set" do
+          context 'when the time format is set' do
             before do
               MultiparameterDateTime.time_format = '%H%M hours'
             end
 
-            it "formats the time properly" do
+            it 'formats the time properly' do
               expect(subject.foo_time_part).to eq '1330 hours'
             end
 
-            it "uses the default format for the date" do
+            it 'uses the default format for the date' do
               expect(subject.foo_date_part).to eq '1/9/2000'
             end
 

--- a/spec/multiparameter_date_time_spec.rb
+++ b/spec/multiparameter_date_time_spec.rb
@@ -91,9 +91,30 @@ describe MultiparameterDateTime do
           it 'has the original time input' do
             expect(subject.foo_time_part).to eq '9:30 pm'
           end
+
+          context 'valid month but invalid day for the month' do
+            let(:foo_date_part) { '2/31/2015' }
+            let(:foo_time_part) { '9:30 pm' }
+
+            it 'does not raise an exception' do
+              expect { subject }.not_to raise_exception
+            end
+
+            it 'sets the attribute to :incomplete' do
+              expect(subject.foo).to eq :incomplete
+            end
+
+            it 'has the original date' do
+              expect(subject.foo_date_part).to eq '2/31/2015'
+            end
+
+            it 'has the original time input' do
+              expect(subject.foo_time_part).to eq '9:30 pm'
+            end
+          end
         end
 
-        describe 'setting a impossible date' do
+        describe 'setting an impossible date' do
           let(:foo_date_part) { '99/99/9999' }
           let(:foo_time_part) { '12:30 pm' }
 

--- a/spec/multiparameter_date_time_spec.rb
+++ b/spec/multiparameter_date_time_spec.rb
@@ -60,15 +60,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to a DateTime object" do
-            subject.foo.should == Time.zone.parse('1/2/2000 9:30 pm')
+            expect(subject.foo).to eq Time.zone.parse('1/2/2000 9:30 pm')
           end
 
           it "has the original date input" do
-            subject.foo_date_part.should == '01/02/2000'
+            expect(subject.foo_date_part).to eq '01/02/2000'
           end
 
           it "has the original time input" do
-            subject.foo_time_part.should == '9:30 pm EST'
+            expect(subject.foo_time_part).to eq '9:30 pm EST'
           end
         end
 
@@ -81,15 +81,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to :incomplete" do
-            subject.foo.should == :incomplete
+            expect(subject.foo).to eq :incomplete
           end
 
           it "has the original date" do
-            subject.foo_date_part.should == 'bad input'
+            expect(subject.foo_date_part).to eq 'bad input'
           end
 
           it "has the original time input" do
-            subject.foo_time_part.should == '9:30 pm'
+            expect(subject.foo_time_part).to eq '9:30 pm'
           end
         end
 
@@ -102,15 +102,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to :incomplete" do
-            subject.foo.should == :incomplete
+            expect(subject.foo).to eq :incomplete
           end
 
           it "has the original date" do
-            subject.foo_date_part.should == '99/99/9999'
+            expect(subject.foo_date_part).to eq '99/99/9999'
           end
 
           it "has the original time" do
-            subject.foo_time_part.should == '12:30 pm'
+            expect(subject.foo_time_part).to eq '12:30 pm'
           end
         end
 
@@ -123,15 +123,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to :incomplete" do
-            subject.foo.should == :incomplete
+            expect(subject.foo).to eq :incomplete
           end
 
           it "has the original date input" do
-            subject.foo_date_part.should == '01/02/2000'
+            expect(subject.foo_date_part).to eq '01/02/2000'
           end
 
           it "has the original time input" do
-            subject.foo_time_part.should == "bad input"
+            expect(subject.foo_time_part).to eq "bad input"
           end
         end
 
@@ -144,15 +144,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to :incomplete" do
-            subject.foo.should == :incomplete
+            expect(subject.foo).to eq :incomplete
           end
 
           it "has the original date input" do
-            subject.foo_date_part.should == '01/02/2000'
+            expect(subject.foo_date_part).to eq '01/02/2000'
           end
 
           it "has the original time input" do
-            subject.foo_time_part.should == '99:99pm'
+            expect(subject.foo_time_part).to eq '99:99pm'
           end
         end
 
@@ -164,15 +164,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to :incomplete" do
-            subject.foo.should == :incomplete
+            expect(subject.foo).to eq :incomplete
           end
 
           it "has the original date" do
-            subject.foo_date_part.should == '01/01/2000'
+            expect(subject.foo_date_part).to eq '01/01/2000'
           end
 
           it "has the nil for the time input" do
-            subject.foo_time_part.should == nil
+            expect(subject.foo_time_part).to eq nil
           end
         end
 
@@ -184,15 +184,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to :incomplete" do
-            subject.foo.should == :incomplete
+            expect(subject.foo).to eq :incomplete
           end
 
           it "has the nil for the date input" do
-            subject.foo_date_part.should == nil
+            expect(subject.foo_date_part).to eq nil
           end
 
           it "has the original time" do
-            subject.foo_time_part.should == '12:30 pm'
+            expect(subject.foo_time_part).to eq '12:30 pm'
           end
         end
 
@@ -205,15 +205,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to :incomplete" do
-            subject.foo.should == :incomplete
+            expect(subject.foo).to eq :incomplete
           end
 
           it "has the original date" do
-            subject.foo_date_part.should == 'asdf'
+            expect(subject.foo_date_part).to eq 'asdf'
           end
 
           it "has the original time input" do
-            subject.foo_time_part.should == 'qwer'
+            expect(subject.foo_time_part).to eq 'qwer'
           end
         end
 
@@ -226,15 +226,15 @@ describe MultiparameterDateTime do
           end
 
           it "has nil for the attribute" do
-            subject.foo.should == nil
+            expect(subject.foo).to eq nil
           end
 
           it "has the original date" do
-            subject.foo_date_part.should == ''
+            expect(subject.foo_date_part).to eq ''
           end
 
           it "has the original time input" do
-            subject.foo_time_part.should == ''
+            expect(subject.foo_time_part).to eq ''
           end
         end
 
@@ -248,15 +248,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to a DateTime object" do
-            subject.foo.should == Time.zone.parse('01/02/2000 12:30 pm')
+            expect(subject.foo).to eq Time.zone.parse('01/02/2000 12:30 pm')
           end
 
           it "has the original date" do
-            subject.foo_date_part.should == '1/2/2000'
+            expect(subject.foo_date_part).to eq '1/2/2000'
           end
 
           it "has the original time input" do
-            subject.foo_time_part.should == '12:30 pm'
+            expect(subject.foo_time_part).to eq '12:30 pm'
           end
         end
 
@@ -271,15 +271,15 @@ describe MultiparameterDateTime do
             end
 
             it "sets the attribute to a DateTime object" do
-              subject.foo.should == Time.zone.parse('01/01/2000 12:30pm')
+              expect(subject.foo).to eq Time.zone.parse('01/01/2000 12:30pm')
             end
 
             it "has the original date" do
-              subject.foo_date_part.should == '01/01/2000'
+              expect(subject.foo_date_part).to eq '01/01/2000'
             end
 
             it "has the original time" do
-              subject.foo_time_part.should == '12:30 pm'
+              expect(subject.foo_time_part).to eq '12:30 pm'
             end
           end
 
@@ -291,15 +291,15 @@ describe MultiparameterDateTime do
             end
 
             it "sets the attribute to a DateTime object with the correct EST time" do
-              subject.foo.should == Time.zone.parse('12/2/2011 8:00 pm')
+              expect(subject.foo).to eq Time.zone.parse('12/2/2011 8:00 pm')
             end
 
             it "has a date" do
-              subject.foo_date_part.should == '12/2/2011'
+              expect(subject.foo_date_part).to eq '12/2/2011'
             end
 
             it "has a time" do
-              subject.foo_time_part.should == '8:00 pm'
+              expect(subject.foo_time_part).to eq '8:00 pm'
             end
           end
 
@@ -312,15 +312,15 @@ describe MultiparameterDateTime do
             end
 
             it "sets the attribute to a DateTime object" do
-              subject.foo.should == Time.zone.parse('01/01/2000 12:00am')
+              expect(subject.foo).to eq Time.zone.parse('01/01/2000 12:00am')
             end
 
             it "has the original date" do
-              subject.foo_date_part.should == '1/1/2000'
+              expect(subject.foo_date_part).to eq '1/1/2000'
             end
 
             it "has midnight for the time input" do
-              subject.foo_time_part.should == '12:00 am'
+              expect(subject.foo_time_part).to eq '12:00 am'
             end
           end
         end
@@ -335,15 +335,15 @@ describe MultiparameterDateTime do
           end
 
           it "sets the attribute to a DateTime object in the current time zone" do
-            subject.foo.should == Time.zone.parse('01/01/2000 12:00 am')
+            expect(subject.foo).to eq Time.zone.parse('01/01/2000 12:00 am')
           end
 
           it "has the original date" do
-            subject.foo_date_part.should == '1/1/2000'
+            expect(subject.foo_date_part).to eq '1/1/2000'
           end
 
           it "has midnight for the time input" do
-            subject.foo_time_part.should == '12:00 am'
+            expect(subject.foo_time_part).to eq '12:00 am'
           end
         end
 
@@ -364,12 +364,12 @@ describe MultiparameterDateTime do
               MultiparameterDateTime.date_format = '%-m-%-e-%0y'
             end
 
-            it "should format the date properly" do
-              subject.foo_date_part.should == '1-9-00'
+            it "formats the date properly" do
+              expect(subject.foo_date_part).to eq '1-9-00'
             end
 
-            it "should use the default format for the time" do
-              subject.foo_time_part.should == '1:30 pm'
+            it "uses the default format for the time" do
+              expect(subject.foo_time_part).to eq '1:30 pm'
             end
 
             after do
@@ -382,12 +382,12 @@ describe MultiparameterDateTime do
               MultiparameterDateTime.time_format = '%H%M hours'
             end
 
-            it "should format the time properly" do
-              subject.foo_time_part.should == '1330 hours'
+            it "formats the time properly" do
+              expect(subject.foo_time_part).to eq '1330 hours'
             end
 
-            it "should use the default format for the date" do
-              subject.foo_date_part.should == '1/9/2000'
+            it "uses the default format for the date" do
+              expect(subject.foo_date_part).to eq '1/9/2000'
             end
 
             after do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/105347574
If user enters an invalid date of 2/31/2015 instead of 1/31/2015 it gets converted to 3/3/2015. Instead it should return an error message.